### PR TITLE
Improved very small styling

### DIFF
--- a/test/helpers/classlist.js
+++ b/test/helpers/classlist.js
@@ -9,7 +9,7 @@ beforeEach(() => {
             : el.getAttribute('class').split(/\s+/g).indexOf(cls) > -1
           return {
             pass,
-            message: `Expected element${pass ? ' ' : ' not '}to have class ${cls}`
+            message: `Expected element ${pass ? '' : 'not'} to have class ${cls}`
           }
         }
       }


### PR DESCRIPTION
Replace exception message below:

```js
`Expected element${pass ? ' ' : ' not '}to have class ${cls}`
```
with the code below to improve readability:

```js
`Expected element ${pass ? '' : 'not'} to have class ${cls}`
```